### PR TITLE
feat: 태그 자동완성 기능 구현 및 검색 로그 저장 추가

### DIFF
--- a/src/main/java/com/team1/mixIt/tag/controller/TagAutoCompleteController.java
+++ b/src/main/java/com/team1/mixIt/tag/controller/TagAutoCompleteController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @Tag(name = "태그 자동완성", description = "입력 기반 인기 태그 자동완성")
 @RequiredArgsConstructor
 public class TagAutoCompleteController {
-    private final TagAutoCompleteService svc;
+    private final TagAutoCompleteService tagAutoCompleteService;
 
     @Operation(summary = "태그 자동완성", description = "prefix로 시작하는 태그를 추천 순으로 반환")
     @GetMapping("/autocomplete")
@@ -29,7 +29,7 @@ public class TagAutoCompleteController {
             @RequestParam(value = "limit", defaultValue = "10") int limit,
             @AuthenticationPrincipal User user
     ) {
-        List<AutoCompleteResponse> result = svc.autocomplete(prefix, limit, user);
+        List<AutoCompleteResponse> result = tagAutoCompleteService.autocomplete(prefix, limit, user);
         return ResponseTemplate.ok(result);
     }
 }

--- a/src/main/java/com/team1/mixIt/tag/controller/TagAutoCompleteController.java
+++ b/src/main/java/com/team1/mixIt/tag/controller/TagAutoCompleteController.java
@@ -1,0 +1,35 @@
+// src/main/java/com/team1/mixIt/tag/controller/TagAutoCompleteController.java
+package com.team1.mixIt.tag.controller;
+
+import com.team1.mixIt.common.dto.ResponseTemplate;
+import com.team1.mixIt.tag.dto.response.AutoCompleteResponse;
+import com.team1.mixIt.tag.service.TagAutoCompleteService;
+import com.team1.mixIt.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/tags")
+@Tag(name = "태그 자동완성", description = "입력 기반 인기 태그 자동완성")
+@RequiredArgsConstructor
+public class TagAutoCompleteController {
+    private final TagAutoCompleteService svc;
+
+    @Operation(summary = "태그 자동완성", description = "prefix로 시작하는 태그를 추천 순으로 반환")
+    @GetMapping("/autocomplete")
+    public ResponseTemplate<List<AutoCompleteResponse>> autocomplete(
+            @RequestParam("prefix") String prefix,
+            @RequestParam(value = "limit", defaultValue = "10") int limit,
+            @AuthenticationPrincipal User user
+    ) {
+        List<AutoCompleteResponse> result = svc.autocomplete(prefix, limit, user);
+        return ResponseTemplate.ok(result);
+    }
+}

--- a/src/main/java/com/team1/mixIt/tag/dto/response/AutoCompleteResponse.java
+++ b/src/main/java/com/team1/mixIt/tag/dto/response/AutoCompleteResponse.java
@@ -1,0 +1,10 @@
+package com.team1.mixIt.tag.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AutoCompleteResponse {
+    private final String tag;
+}

--- a/src/main/java/com/team1/mixIt/tag/entity/TagSearchLog.java
+++ b/src/main/java/com/team1/mixIt/tag/entity/TagSearchLog.java
@@ -1,0 +1,4 @@
+package com.team1.mixIt.tag.entity;
+
+public class TagSearchLog {
+}

--- a/src/main/java/com/team1/mixIt/tag/entity/TagSearchLog.java
+++ b/src/main/java/com/team1/mixIt/tag/entity/TagSearchLog.java
@@ -1,4 +1,33 @@
 package com.team1.mixIt.tag.entity;
 
+import com.team1.mixIt.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tag_search_log",
+        indexes = {@Index(name = "idx_tag_searched_at",
+                          columnList = "tag, searched_at")})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
 public class TagSearchLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String tag;
+
+    @Column(name = "searched_at", nullable = false)
+    private LocalDateTime searchedAt = LocalDateTime.now();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
 }

--- a/src/main/java/com/team1/mixIt/tag/entity/TagStats.java
+++ b/src/main/java/com/team1/mixIt/tag/entity/TagStats.java
@@ -1,0 +1,30 @@
+package com.team1.mixIt.tag.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tag_stats")
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class TagStats {
+    @Id
+    @Column(length=50)
+    private String tag;
+
+    @Column(name = "use_count", nullable = false)
+    private Long useCount = 0L;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/team1/mixIt/tag/repository/TagSearchLogRepository.java
+++ b/src/main/java/com/team1/mixIt/tag/repository/TagSearchLogRepository.java
@@ -1,0 +1,7 @@
+package com.team1.mixIt.tag.repository;
+
+import com.team1.mixIt.tag.entity.TagSearchLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagSearchLogRepository  extends JpaRepository<TagSearchLog, Long> {
+}

--- a/src/main/java/com/team1/mixIt/tag/repository/TagStatsRepository.java
+++ b/src/main/java/com/team1/mixIt/tag/repository/TagStatsRepository.java
@@ -1,0 +1,12 @@
+package com.team1.mixIt.tag.repository;
+
+import com.team1.mixIt.tag.entity.TagStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TagStatsRepository extends JpaRepository<TagStats, String> {
+    List<TagStats> findTopByTagStartingWithOrderByUseCountDesc(String prefix);
+}

--- a/src/main/java/com/team1/mixIt/tag/service/TagAutoCompleteService.java
+++ b/src/main/java/com/team1/mixIt/tag/service/TagAutoCompleteService.java
@@ -1,0 +1,64 @@
+package com.team1.mixIt.tag.service;
+
+import com.team1.mixIt.common.dto.ResponseTemplate;
+import com.team1.mixIt.tag.dto.response.AutoCompleteResponse;
+import com.team1.mixIt.tag.entity.TagSearchLog;
+import com.team1.mixIt.tag.repository.TagSearchLogRepository;
+import com.team1.mixIt.user.entity.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TagAutoCompleteService {
+    private final TagSearchLogRepository logRepo;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Transactional
+    public List<AutoCompleteResponse> autocomplete(String prefix,
+                                                   int limit,
+                                                   User user) {
+        logRepo.save(TagSearchLog.builder()
+                .tag(prefix)
+                .user(user)
+                .build()
+        );
+
+        String sql = """
+            SELECT s.tag
+              FROM tag_stats s
+              LEFT JOIN (
+                SELECT tag, COUNT(*) AS search_count
+                  FROM tag_search_log
+                 WHERE searched_at >= DATE_SUB(NOW(), INTERVAL :logDays DAY)
+                   AND tag LIKE CONCAT(:prefix, '%')
+                 GROUP BY tag
+              ) l ON s.tag = l.tag
+             WHERE s.tag LIKE CONCAT(:prefix, '%')
+             ORDER BY (s.use_count * :w1
+                     + COALESCE(l.search_count, 0) * :w2) DESC
+             LIMIT :limit
+        """;
+
+        @SuppressWarnings("unchecked")
+        List<String> tags = em.createNativeQuery(sql)
+                .setParameter("prefix", prefix)
+                .setParameter("limit", limit)
+                .setParameter("logDays", 1)      // 최근 1일 검색량 반영
+                .setParameter("w1", 0.7)         // 사용 빈도 가중치
+                .setParameter("w2", 0.3)         // 검색량 가중치
+                .getResultList();
+
+        return tags.stream()
+                .map(AutoCompleteResponse::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/team1/mixIt/user/dto/UserCreateDto.java
+++ b/src/main/java/com/team1/mixIt/user/dto/UserCreateDto.java
@@ -18,7 +18,7 @@ public class UserCreateDto {
     private String nickname;
     private Long imageId;
     private List<Integer> terms;
-
+ㅁ
     public static UserCreateDto of(UserAccountController.CreateUserRequest request) {
         return UserCreateDto.builder()
                 .loginId(request.getLoginId())


### PR DESCRIPTION
## 변경사항

- 태그 자동완성 기능 구현  
  - `GET /api/v1/tags/autocomplete`: 입력한 prefix로 시작하는 인기 태그 추천
- Controller
  - `TagAutoCompleteController` 작성
- Service 및 비즈니스 로직
  - `TagAutoCompleteService` 작성
- 도메인 모델 설계
  - `TagSearchLog` 엔티티 생성 및 `User` 연관관계 매핑
  - `TagStats` 엔티티 작성 (태그 사용량 통계 관리)
- 요청/응답 DTO 작성
  - `AutoCompleteResponse`: 태그 자동완성 응답 DTO
  - Repository 작성 및 쿼리 구현
  - `TagSearchLogRepository`: 검색 기록 저장
  - `TagStatsRepository`: prefix 기반 인기 태그 조회
- 기타
  - Native Query를 사용해 사용량(`use_count`)과 최근 검색량을 반영한 추천 정렬 구현

---

## 리뷰 요청사항

- 태그 추천 Native Query 작성 및 성능 문제 없는지 검토 부탁드립니다.
- DTO와 Entity 매핑 및 데이터 흐름 구조가 자연스러운지 검토 요청드립니다.
- 네이밍, 컨벤션, 설계 측면에서 개선할 부분 있다면 편하게 의견 부탁드립니다.

---
## 관련 이슈
- 

---
리뷰 요청드립니다!
